### PR TITLE
games-util/heroic: add xdg-utils dependency

### DIFF
--- a/games-util/heroic/heroic-1.9.3.ebuild
+++ b/games-util/heroic/heroic-1.9.3.ebuild
@@ -18,7 +18,8 @@ DEPEND="
 	sys-fs/fuse:0
 	sys-apps/gawk
 	dev-python/wheel
-	dev-python/setuptools"
+	dev-python/setuptools
+	x11-misc/xdg-utils"
 RDEPEND="${DEPEND}"
 BDEPEND=""
 


### PR DESCRIPTION
x11-misc/xdg-utils is required for the "Epic Store here" link on first launch